### PR TITLE
解决了在离线、非离线状态下查看资源的问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ plugins:
 ##secret_key    上传密钥SecretKey
 ##dirPrefix     上传的资源子目录前缀.如设置，需与urlPrefix同步 
 ##urlPrefix     外链前缀. 
-##local_dir     本地目录. ##TODO
+##local_dir     本地目录.在hexo主目录.
 ##image/js/css  子参数folder为不同静态资源种类的目录名称，一般不需要改动
 qiniu:
   offline: false
@@ -38,7 +38,7 @@ qiniu:
   secret_key: SecretKey
   dirPrefix: static
   urlPrefix: http://bucket_name.qiniudn.com/static
-  local_dir: source\static
+  local_dir: static
   image: 
     folder: images
   js:
@@ -88,4 +88,3 @@ qiniu:
 
 ## TODO  
 1.thumbnail image.  
-2.Static resource directory.  

--- a/cmd.js
+++ b/cmd.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var log = hexo.log;
 var config = require('./config')(hexo);
 var sync = require('./sync');
@@ -7,6 +8,20 @@ var package_info = require('./package.json');
 var commands = module.exports = function(hexo) {
     return commands;
 };
+
+var mkcdndir = function (dirpath) {
+    fs.exists(dirpath, function(exists){
+        if (!exists) {
+            fs.mkdirSync(dirpath);
+        }
+    });
+};
+
+var local_dir = config.local_dir ? config.local_dir : 'cdn';
+mkcdndir(local_dir);
+mkcdndir(path.join(local_dir, config.image.folder));
+mkcdndir(path.join(local_dir, config.js.folder));
+mkcdndir(path.join(local_dir, config.css.folder));
 
 commands.sync = function(){
     sync.sync();
@@ -20,13 +35,26 @@ commands.info = function(){
     console.log('Bugs'.bold + ':    ' + package_info.bugs.url);
 };
 
+hexo.on('ready', sync.unsymlink);
+hexo.on('exit', sync.unsymlink);
+
 if(config.offline){
     log.w('qiniu sync is offline mode');
+    hexo.on('generateAfter', function(){
+        sync.symlink(true);
+    });
+    hexo.on('server', function(){
+        sync.symlink(false);
+    });
 }else{
     if(config.sync ){
         hexo.on('generateBefore', sync.watch);
         hexo.on('server', sync.watch);
     }else{
         log.w('qiniu sync is off');
-    }    
+        hexo.on('server', function(){
+            sync.symlink(false);
+        });
+    }
+    hexo.on('deployBefore',sync.unsymlink);   
 }

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 var defaults = require('./default');
 var _ = require('lodash');
+var path = require('path');
 var log = hexo.log;
 
 // 七牛的配置组
@@ -8,7 +9,7 @@ if(qnConfig.offline){
 	// 离线状态不进行同步，覆盖同步配置，
 	qnConfig.sync = false;
 	// 离线状态渲染的的链接路径也是本地的，覆盖urlPrefix配置
-	qnConfig.urlPrefix = [hexo.config.root,qnConfig.local_dir].join('');
+	qnConfig.url_Prefix = path.join(hexo.config.root, qnConfig.local_dir).replace(/\\/g, '/');
 }else{
 	// 在线状态要看是否同步
 	if(qnConfig.sync){
@@ -23,15 +24,17 @@ if(qnConfig.offline){
 		throw new Error('bucket and urlPrefix must has one');
 		}else{
 			// 没有配置urlPrefix时根据bucket生成
-			qnConfig.urlPrefix = ['http://',qnConfig.bucket,'.qiniudn.com',dirPrefix ? '/' + dirPrefix : ''].join('');
+			qnConfig.url_Prefix = ['http://',qnConfig.bucket,'.qiniudn.com',dirPrefix ? '/' + dirPrefix : ''].join('');
 		}
+	} else {
+		qnConfig.url_Prefix = qnConfig.urlPrefix;
 	}
 }
 log.i('-----------------------------------------------------------');
 log.i('qiniu state: '.yellow + (qnConfig.offline ? 'offline' : 'online'));
 log.i('qiniu sync:  '.yellow + (qnConfig.sync ? 'true' : 'false'));
 log.i('qiniu local dir:  '.yellow + qnConfig.local_dir);
-log.i('qiniu url:   '.yellow + qnConfig.urlPrefix);
+log.i('qiniu url:   '.yellow + qnConfig.url_Prefix);
 log.i('-----------------------------------------------------------');
 module.exports = function(){
 	return qnConfig;

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ var log = hexo.log;
 var package_info = require('./package.json');
 
 // 图片文件夹路径
-var imgPrefix = [config.urlPrefix, '/', config.image.folder].join('');
+var imgPrefix = [config.url_Prefix, '/', config.image.folder].join('').replace(/\/$/, '');
 // 脚本文件夹路径
-var jsPrefix = [config.urlPrefix, '/', config.js.folder].join('');
+var jsPrefix = [config.url_Prefix, '/', config.js.folder].join('').replace(/\/$/, '');
 // 样式表文件夹路径
-var cssPrefix = [config.urlPrefix, '/', config.css.folder].join('');
+var cssPrefix = [config.url_Prefix, '/', config.css.folder].join('').replace(/\/$/, '');
 
 /** 
  * 将markdown里的tag 数组解析成配置对象<br/>
@@ -76,7 +76,7 @@ var qnJsHelper = function(path){
 };
 
 var qnUrlHelper = function(path){
-  return [config.urlPrefix, '/', path].join('');
+  return [config.url_Prefix, '/', path].join('');
 };
 
 hexo.extend.tag.register('qnimg',qnImgTag);

--- a/sync.js
+++ b/sync.js
@@ -4,6 +4,8 @@ var path = require('path');
 var log = hexo.log;
 var config = require('./config')(hexo);
 var chokidar = require('chokidar');
+var publicDir = hexo.public_dir;
+var sourceDir = hexo.source_dir;
 
 var local_dir = config.local_dir ? config.local_dir : 'cdn';
 var dirPrefix = config.dirPrefix ? config.dirPrefix : '';
@@ -72,7 +74,36 @@ var sync = function (dir) {
     }
 };
 
+var symlink = function (publicdir){
+    var dirpath = path.join(publicdir ? publicDir : sourceDir, local_dir);
+    fs.exists(dirpath, function(exists){
+        if (!exists) {
+            fs.symlinkSync(local_dir, dirpath, 'junction');
+        } else {
+            log.w('dir exists,can\'t symlink:' + dirpath);
+        }
+    });
+};
+
+var unsymlink = function (dirpath){
+    fs.exists(dirpath, function(exists){
+        if (exists) {
+            issymlink = fs.lstatSync(dirpath).isSymbolicLink();
+            if (issymlink) {
+                fs.unlink(dirpath);
+            }
+        }
+    });
+};
+
+var unsymlinkall = function (){
+    unsymlink( path.join(publicDir, local_dir));
+    unsymlink( path.join(sourceDir, local_dir));
+};
+
 module.exports = {
     sync:sync,
-    watch:watch
+    watch:watch,
+    symlink:symlink,
+    unsymlink:unsymlinkall
 };


### PR DESCRIPTION
使用此插件，设置好参数，首次运行会自动在hexo主目录创建对应的文件夹。
以后将图片、JS、CSS放到对应文件夹内。
无论是否离线、在线同步，在预览时都可以正常访问到资源。

注意：如果使用了hexo-console-optimize这类JS、CSS、HTML、图片优化插件，其优化会对静态文件夹内的文件产生作用。
七牛同步有一个需要注意的事项：如果一个文件已经同步过一次，以后的同步将被直接跳过。其文件的更新将被忽略，需要手动去七牛后台删除已上传的文件。