### PR TITLE
更新README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ npm install hexo-qiniu-sync --save
 And add this plugin in your ``_config.yml``.
 
 ```
-plugins:
-  - hexo-qiniu-sync
-
 #hexo-qiniu-sync plugin config
 qiniu:
   bucket: gyk001


### PR DESCRIPTION
Hero v3.2，不需要在_config.xml中添加plugins配置，否则会报错（TypeError: Cannot read property 'compile' of undefined）